### PR TITLE
Fix a bug on production.

### DIFF
--- a/app.R
+++ b/app.R
@@ -506,7 +506,7 @@ ui <- secure_app(
           DTOutput("synthea_observations"),
           downloadButton("downloadSyntheaObservations", "Download Data", style = 'padding:4px; font-size:80%;')
       ))
-      ),
+      )
     )
   )
   ,


### PR DESCRIPTION
Deleting this comma was necessary to get prod to work, although the old version was working fine with a later version of Shiny on my local dev environment.